### PR TITLE
Remove token auth from WebSocket subscribe handler and update tests

### DIFF
--- a/lib/wsServer.test.ts
+++ b/lib/wsServer.test.ts
@@ -10,12 +10,6 @@ jest.mock('livekit-server-sdk', () => {
         { name: 'Bob', metadata: '{}' },
       ]),
     })),
-    TokenVerifier: jest.fn().mockImplementation(() => ({
-      verify: jest.fn().mockResolvedValue({
-        video: { roomJoin: true, room: 'room1' },
-        sub: 'user1',
-      }),
-    })),
   };
 });
 
@@ -53,7 +47,7 @@ describe('handleNewConnection - subscribe', () => {
     const messageListener = getListener(ws, 'message');
     expect(messageListener).toBeDefined();
 
-    await messageListener!(Buffer.from(JSON.stringify({ action: 'subscribe', roomName: 'room1', token: 'valid-token' })));
+    await messageListener!(Buffer.from(JSON.stringify({ action: 'subscribe', roomName: 'room1' })));
 
     // Wait for async listParticipants
     await new Promise((r) => setTimeout(r, 20));
@@ -70,55 +64,16 @@ describe('handleNewConnection - subscribe', () => {
     expect(sent.participants[1]).toEqual({ nickname: 'Bob', avatarUrl: '' });
   });
 
-  it('rejects subscribe with no token and sends Unauthorized', async () => {
-    const ws = mockWs();
-    handleNewConnection(ws);
-    const messageListener = getListener(ws, 'message');
-
-    await messageListener!(Buffer.from(JSON.stringify({ action: 'subscribe', roomName: 'room1' })));
-    await new Promise((r) => setTimeout(r, 20));
-
-    expect(subscriptionMap.has('room1')).toBe(false);
-    const sent = JSON.parse((ws.send as jest.Mock).mock.calls[0][0]);
-    expect(sent.type).toBe('error');
-    expect(sent.message).toBe('Unauthorized');
-  });
-
-  it('rejects subscribe when token is for a different room', async () => {
-    const { TokenVerifier } = jest.requireMock('livekit-server-sdk');
-    TokenVerifier.mockImplementationOnce(() => ({
-      verify: jest.fn().mockResolvedValue({
-        video: { roomJoin: true, room: 'other-room' },
-        sub: 'user1',
-      }),
-    }));
-
-    const ws = mockWs();
-    handleNewConnection(ws);
-    const messageListener = getListener(ws, 'message');
-
-    await messageListener!(Buffer.from(JSON.stringify({ action: 'subscribe', roomName: 'room1', token: 'wrong-room-token' })));
-    await new Promise((r) => setTimeout(r, 20));
-
-    expect(subscriptionMap.has('room1')).toBe(false);
-    const sent = JSON.parse((ws.send as jest.Mock).mock.calls[0][0]);
-    expect(sent.type).toBe('error');
-  });
 });
 
 describe('handleNewConnection - unsubscribe', () => {
   it('removes ws from subscriptionMap', async () => {
-    const { TokenVerifier } = jest.requireMock('livekit-server-sdk');
-    TokenVerifier.mockImplementationOnce(() => ({
-      verify: jest.fn().mockResolvedValue({ video: { roomJoin: true, room: 'room2' }, sub: 'u1' }),
-    }));
-
     const ws = mockWs();
     handleNewConnection(ws);
     const messageListener = getListener(ws, 'message');
 
     // Subscribe first
-    await messageListener!(Buffer.from(JSON.stringify({ action: 'subscribe', roomName: 'room2', token: 'valid-token' })));
+    await messageListener!(Buffer.from(JSON.stringify({ action: 'subscribe', roomName: 'room2' })));
     await new Promise((r) => setTimeout(r, 20));
     expect(subscriptionMap.get('room2')!.has(ws)).toBe(true);
 

--- a/lib/wsServer.ts
+++ b/lib/wsServer.ts
@@ -1,5 +1,5 @@
 import { WebSocket } from 'ws';
-import { RoomServiceClient, TokenVerifier } from 'livekit-server-sdk';
+import { RoomServiceClient } from 'livekit-server-sdk';
 
 declare global {
   var __wsSubscriptionMap: Map<string, Set<WebSocket>> | undefined;
@@ -15,19 +15,9 @@ function getRoomClient(): RoomServiceClient {
   return new RoomServiceClient(url.origin, process.env.LIVEKIT_API_KEY, process.env.LIVEKIT_API_SECRET);
 }
 
-async function verifyRoomToken(token: string, roomName: string): Promise<boolean> {
-  try {
-    const verifier = new TokenVerifier(process.env.LIVEKIT_API_KEY!, process.env.LIVEKIT_API_SECRET!);
-    const claims = await verifier.verify(token);
-    return !!(claims?.video?.roomJoin && claims.video.room === roomName);
-  } catch {
-    return false;
-  }
-}
-
 export function handleNewConnection(ws: WebSocket): void {
   ws.on('message', async (data) => {
-    let msg: { action?: string; roomName?: string; token?: string };
+    let msg: { action?: string; roomName?: string };
     try {
       msg = JSON.parse(data.toString());
     } catch {
@@ -38,14 +28,6 @@ export function handleNewConnection(ws: WebSocket): void {
     if (!action || !roomName) return;
 
     if (action === 'subscribe') {
-      const authorized = msg.token ? await verifyRoomToken(msg.token, roomName) : false;
-      if (!authorized) {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ type: 'error', message: 'Unauthorized' }));
-        }
-        return;
-      }
-
       if (!subscriptionMap.has(roomName)) {
         subscriptionMap.set(roomName, new Set());
       }


### PR DESCRIPTION
Generated with Hive: Remove token auth from WebSocket subscribe handler and update tests